### PR TITLE
Fixed Bug where may_throw guard would pass twice

### DIFF
--- a/nuttiest.hpp
+++ b/nuttiest.hpp
@@ -44,7 +44,7 @@ namespace nuttiest {
 
     /// Enables exception handling. Test will fail if an exception is thrown.
     #define may_throw(y)\
-        try { y; pass_test(); }\
+        try { y; }\
         catch(const std::exception& e) { fail_test(e.what()); }\
         catch(...) { fail_test("Unknown Exception"); }
     


### PR DESCRIPTION
- `may_throw` no longer passes if it doesn't throw. This was never the intended behavior. 
- `may_throw` passes only if the test passes. 